### PR TITLE
bugfix: fix adduser router api and change putUser return message

### DIFF
--- a/controller/usercontroller.js
+++ b/controller/usercontroller.js
@@ -77,12 +77,12 @@ const updateUserAsync = async (req, res) => {
     user.id
   );
   if (!checkUserResult.isSuccess) {
-    res.sendCommonValue({}, "Username already exists", 400, 400);
+    res.sendCommonValue({}, "Username and User ID do not exists", 400, 400);
     return;
   }
   let dbResult = await userservice.uptUserByIdAsync(user);
   if (dbResult.isSuccess) {
-    res.sendCommonValue(user, "Username already exists", 1);
+    res.sendCommonValue(user, "Updated user succeed", 1);
     return;
   } else {
     res.sendCommonValue({}, "", 0);

--- a/router/userrouter.js
+++ b/router/userrouter.js
@@ -57,7 +57,7 @@ var usercontroller = require("../controller/usercontroller");
  *        description: Server Error
  */
 router.post(
-  "",
+  "/addUser",
   commonValidate([
     body("username").notEmpty().withMessage("Not a valid username"),
     body("password").notEmpty().isLength({ min: 6 }),
@@ -264,7 +264,7 @@ router.put(
  *      500:
  *        description: Server Error
  */
- router.get("/getUserById",
+router.get("/getUserById",
   commonValidate([
     query("id").notEmpty().withMessage("Not a valid id"),
   ]),


### PR DESCRIPTION
Swagger adduser API does not match router API, there is a cannot post issue.

When user id and username do not exist should return the message "Username and User ID do not exist" instead of "Username already exists"